### PR TITLE
Analysis Improvement: JSDoc/Docstring Completeness

### DIFF
--- a/APICallsWithTCA/APICallsWithTCAApp.swift
+++ b/APICallsWithTCA/APICallsWithTCAApp.swift
@@ -1,7 +1,13 @@
 import SwiftUI
 
+/// The main entry point for the API Calls With TCA application.
+///
+/// This app demonstrates API integration using The Composable Architecture pattern.
 @main
 struct APICallsWithTCAApp: App {
+    /// The scene containing the app's user interface.
+    ///
+    /// - Returns: A scene containing the profile view wrapped in a navigation view.
     var body: some Scene {
         WindowGroup {
             NavigationView {

--- a/APICallsWithTCA/APIConfig.swift
+++ b/APICallsWithTCA/APIConfig.swift
@@ -1,6 +1,18 @@
 import Foundation
 
+/// Configuration for API endpoints and network operations.
+///
+/// This enum contains static methods for making API requests to retrieve user data.
 enum APIConfig {
+    
+    /// Fetches user data for a specific user ID from the API.
+    ///
+    /// This method constructs the appropriate URL for the user endpoint,
+    /// makes an asynchronous network request, and handles various response scenarios.
+    ///
+    /// - Parameter id: The unique identifier of the user to fetch.
+    /// - Returns: A Result containing either the successfully retrieved `UserData` or a `UserError`.
+    /// - Throws: May throw system-level errors related to network operations.
     static func getUser(id: Int) async throws -> Result<UserData, UserError> {
         let baseUrl = "https://reqres.in/api/"
         let users = "users/"

--- a/APICallsWithTCA/APIModels.swift
+++ b/APICallsWithTCA/APIModels.swift
@@ -1,24 +1,47 @@
 import Foundation
 
+/// A model representing the response from the single user API endpoint.
+/// Contains the user data wrapped in a `data` property.
 struct SingleUser: Decodable {
+    /// The user data returned by the API.
     var data: UserData
 }
 
+/// A model representing user data returned from the API.
+/// Contains personal information like name, email, and avatar URL.
 struct UserData: Decodable, Equatable {
+    /// The unique identifier for the user.
     var id: Int
+    
+    /// The user's email address.
     var email: String
+    
+    /// The user's first name.
     var firstName: String
+    
+    /// The user's last name.
     var lastName: String
+    
+    /// The URL string for the user's avatar image.
     var avatar: String
     
+    /// The concatenated full name of the user.
+    ///
+    /// Combines the first and last name with a space in between.
+    /// - Returns: A string containing the user's full name.
     var fullName: String {
         "\(firstName) \(lastName)"
     }
 
+    /// The URL object created from the avatar string.
+    ///
+    /// - Returns: A URL object for the user's avatar image.
+    /// - Note: This property force unwraps the URL creation. The API is expected to always provide valid URLs.
     var avatarURL: URL {
         URL(string: avatar)!
     }
 
+    /// Coding keys for mapping JSON keys to struct properties.
     enum CodingKeys: String, CodingKey {
         case id
         case email
@@ -28,9 +51,19 @@ struct UserData: Decodable, Equatable {
     }
 }
 
+/// Error types that can occur during user data retrieval operations.
+///
+/// Each case includes a user-friendly error message as its raw value.
 enum UserError: String, Equatable, Error {
+    /// Occurs when there's a network connectivity issue or the server is unavailable.
     case serverError = "Please check your internet connection  and try again!!!"
+    
+    /// Occurs when attempting to retrieve a user that doesn't exist in the system.
     case invalidUser = "The User doesn't exist, refresh and Try Again!!!"
+    
+    /// Occurs when the API URL is malformed or cannot be constructed properly.
     case invalidUrl =  "Internal Errror refresh and Try Again!!!"
+    
+    /// A general error case for unexpected issues during API operations.
     case internalError =  "Something went wrong refresh and Try Again!!!"
 }

--- a/APICallsWithTCA/ProfileView.swift
+++ b/APICallsWithTCA/ProfileView.swift
@@ -1,21 +1,50 @@
 import SwiftUI
 import ComposableArchitecture
 
+/// A reducer that manages the state and actions for the user profile feature.
+///
+/// This reducer handles loading user data from the API, navigation between users,
+/// and error handling for the profile view.
 struct ProfileFeature: Reducer {
+    /// State for the profile feature.
+    ///
+    /// Contains the current user ID, any error messages, and the API response data.
     struct State: Equatable {
+        /// The ID of the current user being displayed.
+        /// Defaults to 1 for the initial user.
         var id: Int = 1
+        
+        /// Error message to display when an API request fails.
+        /// `nil` when there is no error.
         var errorMessage: String?
+        
+        /// The result of the API request, containing either user data or an error.
+        /// `nil` when no request has been made or a request is in progress.
         var response: Result<UserData, UserError>?
     }
     
+    /// Actions that can be performed within the profile feature.
     enum Action: Equatable {
+        /// Triggered when the user taps the "Next" button to view the next user.
         case nextUserButtonTapped
+        
+        /// Triggered when the user taps the "Previous" button to view the previous user.
         case previousUserButtonTapped
+        
+        /// Triggered when the user taps the "Refresh" button to reset and reload user data.
         case refreshButtonTapped
+        
+        /// Internal action to initiate fetching user data from the API.
         case fetchData
+        
+        /// Internal action containing the response from the API request.
+        /// - Parameter Result: A Result containing either the user data or an error.
         case fetchResponse(Result<UserData, UserError>)
     }
 
+    /// The body of the reducer that handles state changes based on actions.
+    ///
+    /// - Returns: A reducer that processes actions and updates state accordingly.
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
@@ -60,7 +89,12 @@ struct ProfileFeature: Reducer {
     }
 }
 
+/// A view that displays user profile information.
+///
+/// This view uses The Composable Architecture to manage state and user interactions.
+/// It displays user data fetched from the API and provides navigation controls to browse between users.
 struct ProfileView: View {
+    /// The store that manages the state and actions for this view.
     let store: StoreOf<ProfileFeature>
     var body: some View {
         WithViewStore(self.store, observe: {$0}) { viewStore in
@@ -87,6 +121,10 @@ struct ProfileView: View {
         }
     }
     
+    /// Creates a view that displays the user profile information.
+    ///
+    /// - Parameter user: The user data to display in the profile.
+    /// - Returns: A view containing the formatted user profile.
     func profileComponent(_ user: UserData) -> some View {
         VStack {
             Spacer()
@@ -114,6 +152,10 @@ struct ProfileView: View {
         }
     }
 
+    /// Creates the toolbar controls for navigating between users.
+    ///
+    /// - Parameter viewStore: The view store containing the current state and action dispatch capabilities.
+    /// - Returns: Toolbar content with navigation buttons.
     @ToolbarContentBuilder
     func profileControls(
         _ viewStore: ViewStoreOf<ProfileFeature>

--- a/APICallsWithTCATests/APICallsWithTCATests.swift
+++ b/APICallsWithTCATests/APICallsWithTCATests.swift
@@ -8,16 +8,28 @@
 import XCTest
 @testable import APICallsWithTCA
 
+/// Test suite for the APICallsWithTCA application.
+///
+/// Contains tests to verify the functionality of the app's core features.
 final class APICallsWithTCATests: XCTestCase {
 
+    /// Set up method called before each test.
+    ///
+    /// - Throws: Throws an error if setup fails.
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
 
+    /// Tear down method called after each test.
+    ///
+    /// - Throws: Throws an error if tear down fails.
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
+    /// Example test case to demonstrate testing functionality.
+    ///
+    /// - Throws: Throws an error if the test fails.
     func testExample() throws {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
@@ -26,6 +38,9 @@ final class APICallsWithTCATests: XCTestCase {
         // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
     }
 
+    /// Example performance test case to measure code execution time.
+    ///
+    /// - Throws: Throws an error if the test fails.
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         self.measure {

--- a/APICallsWithTCAUITests/APICallsWithTCAUITests.swift
+++ b/APICallsWithTCAUITests/APICallsWithTCAUITests.swift
@@ -7,6 +7,9 @@
 
 import XCTest
 
+/// UI test suite for the APICallsWithTCA application.
+///
+/// Contains tests to verify the user interface functionality of the app.
 final class APICallsWithTCAUITests: XCTestCase {
 
     override func setUpWithError() throws {
@@ -18,10 +21,17 @@ final class APICallsWithTCAUITests: XCTestCase {
         // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
     }
 
+    /// Tear down method called after each UI test.
+    ///
+    /// Cleans up resources after the test has completed.
+    /// - Throws: Throws an error if tear down fails.
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
+    /// Example UI test that launches the application.
+    ///
+    /// - Throws: Throws an error if the test fails.
     func testExample() throws {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
@@ -30,6 +40,9 @@ final class APICallsWithTCAUITests: XCTestCase {
         // Use XCTAssert and related functions to verify your tests produce the correct results.
     }
 
+    /// Performance test that measures application launch time.
+    ///
+    /// - Throws: Throws an error if the test fails.
     func testLaunchPerformance() throws {
         if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
             // This measures how long it takes to launch your application.

--- a/APICallsWithTCAUITests/APICallsWithTCAUITestsLaunchTests.swift
+++ b/APICallsWithTCAUITests/APICallsWithTCAUITestsLaunchTests.swift
@@ -7,16 +7,29 @@
 
 import XCTest
 
+/// UI test suite specifically for testing application launch.
+///
+/// This test case captures screenshots of the launch process and verifies the launch behavior.
 final class APICallsWithTCAUITestsLaunchTests: XCTestCase {
 
+    /// Indicates whether the test should run for each target application UI configuration.
+    ///
+    /// - Returns: `true` to run the test for each configuration, `false` to run once.
     override class var runsForEachTargetApplicationUIConfiguration: Bool {
         true
     }
 
+    /// Set up method called before each launch test.
+    ///
+    /// - Throws: Throws an error if setup fails.
     override func setUpWithError() throws {
         continueAfterFailure = false
     }
 
+    /// Tests the application launch process and captures a screenshot.
+    ///
+    /// This test launches the application and captures a screenshot of the launch screen.
+    /// - Throws: Throws an error if the test fails.
     func testLaunch() throws {
         let app = XCUIApplication()
         app.launch()


### PR DESCRIPTION
Fix for: JSDoc/Docstring Completeness

Action Plan: Implement Swift's documentation comment format (///) for all public APIs, classes, structs, enums, and functions. Follow Swift documentation best practices by including: @param tags for function parameters, @return for return value descriptions, @throws for error conditions. Document generic types and constraints where applicable. Add usage examples for complex components. Consider using a documentation linting tool to enforce documentation standards. Create templates for common documentation patterns to ensure consistency.

