### PR TITLE
Analysis Improvement: JSDoc/docstring documentation completeness

### DIFF
--- a/APICallsWithTCA/APICallsWithTCAApp.swift
+++ b/APICallsWithTCA/APICallsWithTCAApp.swift
@@ -1,7 +1,15 @@
 import SwiftUI
 
+/// The main entry point for the APICallsWithTCA application.
+///
+/// This struct conforms to the App protocol and sets up the initial scene
+/// and view hierarchy for the application.
 @main
 struct APICallsWithTCAApp: App {
+    /// The body of the application that defines its scene structure.
+    ///
+    /// This property creates the main window group containing the ProfileView
+    /// wrapped in a NavigationView.
     var body: some Scene {
         WindowGroup {
             NavigationView {

--- a/APICallsWithTCA/APIConfig.swift
+++ b/APICallsWithTCA/APIConfig.swift
@@ -1,6 +1,33 @@
 import Foundation
 
+/// Provides configuration and methods for API interactions.
+/// This enum contains static methods for making API requests to external services.
 enum APIConfig {
+    
+    /// Fetches user data from the remote API based on the provided user ID.
+    ///
+    /// This function makes an asynchronous network request to retrieve user information
+    /// from the reqres.in API service. It handles various error scenarios and returns
+    /// appropriate error messages.
+    ///
+    /// - Parameter id: The unique identifier of the user to fetch.
+    /// - Returns: A Result containing either the successfully retrieved `UserData` or a `UserError`.
+    /// - Throws: May throw network-related errors during the API call.
+    ///
+    /// - Example:
+    /// ```swift
+    /// do {
+    ///     let result = try await APIConfig.getUser(id: 1)
+    ///     switch result {
+    ///     case .success(let userData):
+    ///         // Process the user data
+    ///     case .failure(let error):
+    ///         // Handle the error
+    ///     }
+    /// } catch {
+    ///     // Handle unexpected errors
+    /// }
+    /// ```
     static func getUser(id: Int) async throws -> Result<UserData, UserError> {
         let baseUrl = "https://reqres.in/api/"
         let users = "users/"
@@ -41,4 +68,3 @@ enum APIConfig {
         }
     }
 }
-

--- a/APICallsWithTCA/APIModels.swift
+++ b/APICallsWithTCA/APIModels.swift
@@ -1,24 +1,59 @@
 import Foundation
 
+/// Represents the response structure from the API for a single user request.
+///
+/// This struct wraps the user data in the format returned by the API,
+/// where user information is nested under a "data" key.
 struct SingleUser: Decodable {
+    /// The actual user data contained in the API response.
     var data: UserData
 }
 
+/// Represents a user's information retrieved from the API.
+///
+/// This struct contains all the personal information about a user
+/// that is available from the API, including identification, contact details,
+/// and profile image.
 struct UserData: Decodable, Equatable {
+    /// The unique identifier for the user.
     var id: Int
+    
+    /// The user's email address.
     var email: String
+    
+    /// The user's first name.
     var firstName: String
+    
+    /// The user's last name.
     var lastName: String
+    
+    /// The URL string for the user's avatar image.
     var avatar: String
     
+    /// The user's full name, combining first and last name.
+    ///
+    /// This computed property concatenates the user's first and last name
+    /// to create a complete display name.
+    ///
+    /// - Returns: A string containing the user's full name.
     var fullName: String {
         "\(firstName) \(lastName)"
     }
 
+    /// The URL object for the user's avatar.
+    ///
+    /// This computed property converts the avatar string URL into a proper URL object
+    /// for use with SwiftUI's AsyncImage and other URL-based APIs.
+    ///
+    /// - Returns: A URL object pointing to the user's avatar image.
     var avatarURL: URL {
         URL(string: avatar)!
     }
 
+    /// Defines the mapping between JSON keys and struct properties.
+    ///
+    /// This enum handles the snake_case to camelCase conversion for properties
+    /// that have different naming conventions between the API and Swift code.
     enum CodingKeys: String, CodingKey {
         case id
         case email
@@ -28,9 +63,20 @@ struct UserData: Decodable, Equatable {
     }
 }
 
+/// Represents possible errors that can occur during API operations.
+///
+/// This enum defines various error types that might be encountered when
+/// interacting with the API, providing user-friendly error messages.
 enum UserError: String, Equatable, Error {
+    /// Error indicating server connectivity issues.
     case serverError = "Please check your internet connection  and try again!!!"
+    
+    /// Error indicating the requested user doesn't exist.
     case invalidUser = "The User doesn't exist, refresh and Try Again!!!"
+    
+    /// Error indicating an invalid URL was constructed.
     case invalidUrl =  "Internal Errror refresh and Try Again!!!"
+    
+    /// Error indicating an unexpected internal error occurred.
     case internalError =  "Something went wrong refresh and Try Again!!!"
 }

--- a/APICallsWithTCA/ProfileView.swift
+++ b/APICallsWithTCA/ProfileView.swift
@@ -1,21 +1,45 @@
 import SwiftUI
 import ComposableArchitecture
 
+/// A reducer that manages the state and actions for the profile feature.
+///
+/// This reducer handles loading user profiles, navigating between users,
+/// and managing error states using The Composable Architecture pattern.
 struct ProfileFeature: Reducer {
+    /// Represents the state of the profile feature.
+    ///
+    /// Contains the current user ID, any error messages, and the API response.
     struct State: Equatable {
+        /// The ID of the currently displayed user.
         var id: Int = 1
+        
+        /// Error message to display if an API request fails.
         var errorMessage: String?
+        
+        /// The result of the API request, containing either user data or an error.
         var response: Result<UserData, UserError>?
     }
     
+    /// Defines the actions that can be performed in the profile feature.
     enum Action: Equatable {
+        /// Action to navigate to the next user.
         case nextUserButtonTapped
+        
+        /// Action to navigate to the previous user.
         case previousUserButtonTapped
+        
+        /// Action to reset and refresh the current user data.
         case refreshButtonTapped
+        
+        /// Action to initiate a data fetch from the API.
         case fetchData
+        
+        /// Action containing the response from the API.
+        /// - Parameter Result: Contains either the user data or an error.
         case fetchResponse(Result<UserData, UserError>)
     }
 
+    /// The body of the reducer that handles state transitions based on actions.
     var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
@@ -60,8 +84,15 @@ struct ProfileFeature: Reducer {
     }
 }
 
+/// The main view for displaying user profiles.
+///
+/// This view handles the presentation of user data, loading states, and error messages.
+/// It also provides navigation controls to move between different user profiles.
 struct ProfileView: View {
+    /// The store that manages the state and actions for this view.
     let store: StoreOf<ProfileFeature>
+    
+    /// The body of the view that defines its appearance and behavior.
     var body: some View {
         WithViewStore(self.store, observe: {$0}) { viewStore in
             VStack {
@@ -87,6 +118,10 @@ struct ProfileView: View {
         }
     }
     
+    /// Creates the profile component that displays user information.
+    ///
+    /// - Parameter user: The user data to display.
+    /// - Returns: A view containing the user's profile information.
     func profileComponent(_ user: UserData) -> some View {
         VStack {
             Spacer()
@@ -114,6 +149,10 @@ struct ProfileView: View {
         }
     }
 
+    /// Creates the toolbar controls for navigating between profiles.
+    ///
+    /// - Parameter viewStore: The view store that manages the state and actions.
+    /// - Returns: Toolbar content containing navigation and refresh controls.
     @ToolbarContentBuilder
     func profileControls(
         _ viewStore: ViewStoreOf<ProfileFeature>

--- a/APICallsWithTCATests/APICallsWithTCATests.swift
+++ b/APICallsWithTCATests/APICallsWithTCATests.swift
@@ -8,16 +8,34 @@
 import XCTest
 @testable import APICallsWithTCA
 
+/// Test suite for the APICallsWithTCA application.
+///
+/// This class contains tests to verify the functionality of various components
+/// in the application, including API calls, data parsing, and UI interactions.
 final class APICallsWithTCATests: XCTestCase {
 
+    /// Set up method called before each test.
+    ///
+    /// Use this method to prepare the test environment, such as initializing test data,
+    /// creating mock objects, or setting up network conditions.
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
 
+    /// Tear down method called after each test.
+    ///
+    /// Use this method to clean up resources used during tests, reset state,
+    /// or restore the environment to its original condition.
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
+    /// Example test case for demonstrating test functionality.
+    ///
+    /// This test is a placeholder that can be expanded to test specific features
+    /// of the application.
+    ///
+    /// - Throws: An error if the test fails unexpectedly.
     func testExample() throws {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
@@ -26,6 +44,12 @@ final class APICallsWithTCATests: XCTestCase {
         // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
     }
 
+    /// Example performance test.
+    ///
+    /// This test measures the performance of a code block and reports the results.
+    /// Use this pattern to identify performance bottlenecks or regressions.
+    ///
+    /// - Throws: An error if the test fails unexpectedly.
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         self.measure {

--- a/Documentation_Templates.md
+++ b/Documentation_Templates.md
@@ -1,0 +1,96 @@
+# Swift Documentation Templates
+
+This file provides templates for consistent documentation comments throughout the codebase.
+
+## Class/Struct/Enum Documentation Template
+
+```swift
+/// A brief description of the type.
+///
+/// A more detailed description that explains the purpose and functionality
+/// of this type. Include any important details about how to use it.
+struct/class/enum TypeName {
+    // Implementation
+}
+```
+
+## Function Documentation Template
+
+```swift
+/// A brief description of what the function does.
+///
+/// A more detailed description of the function's purpose, behavior, and any
+/// special considerations when using it.
+///
+/// - Parameter paramName: Description of the parameter.
+/// - Returns: Description of what the function returns.
+/// - Throws: Description of the errors that can be thrown (if applicable).
+///
+/// - Example:
+/// ```swift
+/// // Example usage of the function
+/// let result = myFunction(param: value)
+/// ```
+func myFunction(param: ParamType) -> ReturnType {
+    // Implementation
+}
+```
+
+## Property Documentation Template
+
+```swift
+/// A description of what this property represents.
+///
+/// Include additional details about the property's purpose, behavior,
+/// or any side effects of accessing it.
+var propertyName: PropertyType
+```
+
+## Computed Property Documentation Template
+
+```swift
+/// A description of what this computed property represents.
+///
+/// Include details about how the property is calculated and any
+/// side effects of accessing it.
+///
+/// - Returns: Description of the value returned.
+var computedProperty: PropertyType {
+    // Implementation
+}
+```
+
+## Extension Documentation Template
+
+```swift
+/// Extension providing additional functionality to TypeName.
+///
+/// Describe the general purpose of this extension and what capabilities
+/// it adds to the extended type.
+extension TypeName {
+    // Implementation
+}
+```
+
+## Protocol Documentation Template
+
+```swift
+/// A brief description of the protocol's purpose.
+///
+/// A more detailed description of what conforming types should implement
+/// and the behavior expected of them.
+protocol ProtocolName {
+    // Requirements
+}
+```
+
+## Documentation Best Practices
+
+1. **Be Concise**: Keep descriptions clear and to the point.
+2. **Use Complete Sentences**: Start with a capital letter and end with a period.
+3. **Describe Parameters Thoroughly**: Explain what each parameter is for and any constraints.
+4. **Document Throws Clauses**: List all possible errors that can be thrown.
+5. **Include Examples**: For complex functions or types, provide usage examples.
+6. **Document Side Effects**: Mention any side effects a function might have.
+7. **Use Markdown**: Use formatting like *italics*, **bold**, `code`, and code blocks where appropriate.
+8. **Keep Documentation Updated**: Update documentation when code changes.


### PR DESCRIPTION
Fix for: JSDoc/docstring documentation completeness

Action Plan: Implement Swift documentation comments (///) for all public interfaces, including classes, structs, enums, and functions. Document parameters, return values, and potential errors for all functions, especially those in the API layer. Add example usage where appropriate, particularly for complex components. Document computed properties to explain their purpose and behavior. Create documentation for test cases explaining what they're testing and expected outcomes. Consider using tools like Jazzy to generate documentation from properly formatted comments. Create a documentation template for different types of code elements to ensure consistency.

